### PR TITLE
verify_fixes: catch floating tags

### DIFF
--- a/work/verify_fixes.sh
+++ b/work/verify_fixes.sh
@@ -76,7 +76,11 @@ verify_fixes()
 			sha=
 			subject=
 			msg=
-
+			
+			if git log -1 --format='%B' "$c" | tr '\n' '#' | grep -qF "##$fline##"; then
+				msg="${msg:+${msg}${nl}}${tab}${tab}- empty lines surround the Fixes tag"
+			fi
+			
 			if [[ "$f" =~ $split_re ]]; then
 				first="${BASH_REMATCH[1]}"
 				sha="${BASH_REMATCH[2]}"


### PR DESCRIPTION
There is a common mistake that people make, where the fixes tag is separated
from other tags by empty lines. This is perhaps not invalid, but worth catching
before such patch is applied.

Since commit logs are unlikely to contain # at the start of the line for simplicity
of matching replace new lines with hashes.